### PR TITLE
Add VNC-enabled browser container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM mrcolorrain/vnc-browser:latest
+
+USER root
+
+# Set display number for Xvfb
+ENV DISPLAY=:0
+
+# Install tools to fetch MetaMask extension
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download the MetaMask extension
+RUN mkdir -p /opt/metamask \
+    && wget -qO /tmp/metamask.zip https://github.com/MetaMask/metamask-extension/releases/latest/download/metamask-chrome.zip \
+    && unzip /tmp/metamask.zip -d /opt/metamask \
+    && rm /tmp/metamask.zip
+
+# Startup script that launches the browser with MetaMask
+COPY start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
+
+# Static page for decrypting private keys
+COPY keys.html /keys.html
+
+EXPOSE 5900
+
+CMD ["/usr/local/bin/start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # secure-browser-metamask
-A docker image to run metamask and browser to securely load your dev wallets
+
+A docker image to run MetaMask and a Chromium browser in an isolated
+environment. The container is based on the `mrcolorrain/vnc-browser` image and
+preloads the MetaMask extension. It exposes a VNC server so you can interact with the
+browser without sharing your host credentials.
+
+## Build
+
+```bash
+docker build -t secure-browser-metamask .
+```
+
+## Run
+
+```bash
+docker run -p 5900:5900 secure-browser-metamask
+```
+
+Then connect your VNC client to `localhost:5900` and configure MetaMask or
+browse as needed. Once the container is stopped everything in the session is
+lost.
+
+## Import encrypted keys
+
+Create a `keys.json` (or `.env`) file containing your encrypted private keys
+and mount it into the container:
+
+```bash
+docker run -p 5900:5900 -v /path/to/keys.json:/keys.json:ro secure-browser-metamask
+```
+
+On start the browser opens `keys.html` which loads the encrypted keys, asks for
+a password, and displays the decrypted keys for you to copy into MetaMask.

--- a/keys.html
+++ b/keys.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Decrypt Private Keys</title>
+</head>
+<body>
+  <h1>Decrypt Private Keys</h1>
+  <p>Encrypted keys are loaded from <code>keys.json</code> or <code>.env</code> in the same directory.</p>
+  <label>Password: <input type="password" id="password" /></label>
+  <button id="decrypt">Decrypt</button>
+  <pre id="output"></pre>
+  <script>
+    async function loadConfig() {
+      const sources = ['keys.json', '.env'];
+      for (const src of sources) {
+        try {
+          const res = await fetch(src);
+          if (!res.ok) continue;
+          if (src.endsWith('.json')) {
+            return res.json();
+          } else {
+            const text = await res.text();
+            const keys = [];
+            for (const line of text.split('\n')) {
+              const match = line.match(/^KEY_[^=]+=([^:]+):(.+)$/);
+              if (match) {
+                keys.push({ iv: match[1].trim(), data: match[2].trim() });
+              }
+            }
+            if (keys.length) return { keys };
+          }
+        } catch (e) {
+          // ignore
+        }
+      }
+      return null;
+    }
+
+    async function deriveKey(password, salt) {
+      const enc = new TextEncoder();
+      const keyMaterial = await crypto.subtle.importKey(
+        'raw', enc.encode(password), 'PBKDF2', false, ['deriveKey']
+      );
+      return crypto.subtle.deriveKey(
+        { name: 'PBKDF2', salt: enc.encode(salt), iterations: 100000, hash: 'SHA-256' },
+        keyMaterial,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['decrypt']
+      );
+    }
+
+    async function decrypt() {
+      const output = document.getElementById('output');
+      output.textContent = '';
+      const config = await loadConfig();
+      if (!config) {
+        output.textContent = 'No config file found.';
+        return;
+      }
+      const password = document.getElementById('password').value;
+      const results = [];
+      for (const k of config.keys) {
+        try {
+          const key = await deriveKey(password, k.salt || '');
+          const iv = Uint8Array.from(atob(k.iv), c => c.charCodeAt(0));
+          const data = Uint8Array.from(atob(k.data), c => c.charCodeAt(0));
+          const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+          results.push(new TextDecoder().decode(decrypted));
+        } catch (err) {
+          results.push('Error decrypting key: ' + err.message);
+        }
+      }
+      output.textContent = results.join('\n');
+    }
+
+    document.getElementById('decrypt').addEventListener('click', decrypt);
+  </script>
+</body>
+</html>

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+BROWSER=$(command -v chromium-browser || command -v chromium || command -v google-chrome || command -v google-chrome-stable)
+
+# Start virtual framebuffer
+Xvfb :0 -screen 0 1920x1080x24 &
+XVFB_PID=$!
+
+# Start a window manager so the browser has something to talk to
+fluxbox &
+
+# Start VNC server exposing the Xvfb display
+x11vnc -display :0 -nopw -forever -shared -geometry 1920x1080 &
+
+# Launch the browser with the MetaMask extension
+"$BROWSER" \
+    --no-sandbox \
+    --disable-dev-shm-usage \
+    --load-extension=/opt/metamask \
+    file:///keys.html &
+
+wait $XVFB_PID


### PR DESCRIPTION
## Summary
- base the image on `mrcolorrain/vnc-browser` and preinstall MetaMask
- start script opens a helper page to decrypt mounted encrypted keys for pasting into MetaMask
- document mounting `keys.json` or `.env` to supply encrypted private keys

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cfbf8b70c832db712374650d8356d